### PR TITLE
Check if dashboard exists before accessing it

### DIFF
--- a/events/client/ready.js
+++ b/events/client/ready.js
@@ -17,7 +17,7 @@ module.exports = class {
     // const discordbotsorg = require('../helpers/discordbots.org.js');
     // discordbotsorg.init(client);
 
-    if (client.config.dashboard.enabled) {
+    if (client.config.dashboard && client.config.dashboard.enabled) {
       client.dashboard.load(client);
     }
 


### PR DESCRIPTION
Checks if a dashboard exists before accessing it, thereby preventing pollution with an error.